### PR TITLE
fix(SetupPollCommand): run poll setup on background thread.

### DIFF
--- a/src/main/java/me/kmaxi/wynnvp/AsyncConfig.java
+++ b/src/main/java/me/kmaxi/wynnvp/AsyncConfig.java
@@ -1,0 +1,23 @@
+package me.kmaxi.wynnvp;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
+
+@Configuration
+public class AsyncConfig {
+
+    @Bean
+    public Executor pollSetupExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(2);
+        executor.setMaxPoolSize(5);
+        executor.setQueueCapacity(10);
+        executor.setThreadNamePrefix("poll-setup-");
+        executor.setWaitForTasksToCompleteOnShutdown(true);
+        executor.initialize();
+        return executor;
+    }
+}

--- a/src/main/java/me/kmaxi/wynnvp/controller/discordcommands/SetupPollCommand.java
+++ b/src/main/java/me/kmaxi/wynnvp/controller/discordcommands/SetupPollCommand.java
@@ -94,8 +94,12 @@ public class SetupPollCommand implements ICommandImpl {
                             PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("rwx------"));
                     tempDir = Files.createTempDirectory("poll-setup-", ownerOnly);
                 } catch (UnsupportedOperationException e) {
-                    // Non-POSIX filesystem (e.g. Windows) — default temp dir permissions apply
+                    // Non-POSIX filesystem (e.g. Windows) — restrict permissions explicitly
                     tempDir = Files.createTempDirectory("poll-setup-");
+                    File dir = tempDir.toFile();
+                    dir.setReadable(true, true);
+                    dir.setWritable(true, true);
+                    dir.setExecutable(true, true);
                 }
 
                 Document doc = Jsoup.connect(url).get();

--- a/src/main/java/me/kmaxi/wynnvp/controller/discordcommands/SetupPollCommand.java
+++ b/src/main/java/me/kmaxi/wynnvp/controller/discordcommands/SetupPollCommand.java
@@ -33,6 +33,8 @@ import java.nio.channels.Channels;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.file.Files;
 import java.util.*;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 @Slf4j
 @Component
@@ -41,6 +43,7 @@ public class SetupPollCommand implements ICommandImpl {
     private final DiscordPollHandler pollHandler;
     private final APIKeys apiKeys;
     private final AudioConversionService audioConversionService;
+    private final ExecutorService executor = Executors.newCachedThreadPool();
 
     public SetupPollCommand(DiscordPollHandler pollHandler, APIKeys apiKeys, AudioConversionService audioConversionService) {
         this.pollHandler = pollHandler;
@@ -79,48 +82,47 @@ public class SetupPollCommand implements ICommandImpl {
 
         String url = Objects.requireNonNull(event.getOption("url")).getAsString();
 
-        try {
-            Document doc = Jsoup.connect(url).get();
-            String castingCallTitle = doc.title();
-            log.info("Title from Casting Call Club: {}", castingCallTitle);
+        executor.submit(() -> {
+            try {
+                Document doc = Jsoup.connect(url).get();
+                String castingCallTitle = doc.title();
+                log.info("Title from Casting Call Club: {}", castingCallTitle);
 
-            String projectId = getProjectId(doc);
-            log.info("Found project ID: {}", projectId);
+                String projectId = getProjectId(doc);
+                log.info("Found project ID: {}", projectId);
 
-            ArrayList<JSONObject> allSubmissions = getAllSubmissions(projectId);
-            log.info("Total submissions fetched: {}", allSubmissions.size());
+                ArrayList<JSONObject> allSubmissions = getAllSubmissions(projectId);
+                log.info("Total submissions fetched: {}", allSubmissions.size());
 
-            event.getChannel().sendMessage("Auditions for " + url).queue();
+                event.getChannel().sendMessage("Auditions for " + url).queue();
 
-            // Group by role name
-            Map<String, List<JSONObject>> byRole = new LinkedHashMap<>();
-            for (JSONObject sub : allSubmissions) {
-                String roleName = sub.getString("roleName").trim();
-                byRole.computeIfAbsent(roleName, k -> new ArrayList<>()).add(sub);
+                // Group by role name
+                Map<String, List<JSONObject>> byRole = new LinkedHashMap<>();
+                for (JSONObject sub : allSubmissions) {
+                    String roleName = sub.getString("roleName").trim();
+                    byRole.computeIfAbsent(roleName, k -> new ArrayList<>()).add(sub);
+                }
+
+                for (Map.Entry<String, List<JSONObject>> entry : byRole.entrySet()) {
+                    String roleName = entry.getKey().replaceAll("[ ,.-]", "_");
+                    String threadName = roleName + " Auditions";
+                    Message startMessage = event.getChannel().sendMessage("Auditions for " + entry.getKey()).complete();
+                    ThreadChannel threadChannelAction = startMessage.createThreadChannel(threadName).complete();
+                    sendAudioFiles(new ArrayList<>(entry.getValue()), threadChannelAction);
+                }
+
+                event.getHook().editOriginal("Finished sending everything").queue();
+
+            } catch (CccAuthException e) {
+                event.getHook().editOriginal("CCC authentication failed — your token is invalid or expired. Please update it in the bot configuration.").queue();
+            } catch (IOException e) {
+                log.error("Error while trying to connect to the URL: {}", url, e);
+                event.getHook().editOriginal("Failed to connect to the URL: " + e.getMessage()).queue();
+            } catch (Exception e) {
+                log.error("Unexpected error during poll setup", e);
+                event.getHook().editOriginal("An error occurred: " + e.getMessage()).queue();
             }
-
-            for (Map.Entry<String, List<JSONObject>> entry : byRole.entrySet()) {
-                String roleName = entry.getKey().replaceAll("[ ,.-]", "_");
-                String threadName = roleName + " Auditions";
-                Message startMessage = event.getChannel().sendMessage("Auditions for " + entry.getKey()).complete();
-                ThreadChannel threadChannelAction = startMessage.createThreadChannel(threadName).complete();
-                sendAudioFiles(new ArrayList<>(entry.getValue()), threadChannelAction);
-            }
-
-        } catch (CccAuthException e) {
-            event.getHook().editOriginal("CCC authentication failed — your token is invalid or expired. Please update it in the bot configuration.").queue();
-            return;
-        } catch (IOException e) {
-            log.error("Error while trying to connect to the URL: {}", url, e);
-            event.getHook().editOriginal("Failed to connect to the URL: " + e.getMessage()).queue();
-            return;
-        } catch (Exception e) {
-            log.error("Unexpected error during poll setup", e);
-            event.getHook().editOriginal("An error occurred: " + e.getMessage()).queue();
-            return;
-        }
-
-        event.getHook().editOriginal("Finished sending everything").queue();
+        });
     }
 
     private String getProjectId(Document doc) {

--- a/src/main/java/me/kmaxi/wynnvp/controller/discordcommands/SetupPollCommand.java
+++ b/src/main/java/me/kmaxi/wynnvp/controller/discordcommands/SetupPollCommand.java
@@ -32,9 +32,9 @@ import java.net.URL;
 import java.nio.channels.Channels;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.*;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
+import java.util.concurrent.Executor;
 
 @Slf4j
 @Component
@@ -43,12 +43,13 @@ public class SetupPollCommand implements ICommandImpl {
     private final DiscordPollHandler pollHandler;
     private final APIKeys apiKeys;
     private final AudioConversionService audioConversionService;
-    private final ExecutorService executor = Executors.newCachedThreadPool();
+    private final Executor pollSetupExecutor;
 
-    public SetupPollCommand(DiscordPollHandler pollHandler, APIKeys apiKeys, AudioConversionService audioConversionService) {
+    public SetupPollCommand(DiscordPollHandler pollHandler, APIKeys apiKeys, AudioConversionService audioConversionService, Executor pollSetupExecutor) {
         this.pollHandler = pollHandler;
         this.apiKeys = apiKeys;
         this.audioConversionService = audioConversionService;
+        this.pollSetupExecutor = pollSetupExecutor;
     }
 
     @Override
@@ -82,8 +83,11 @@ public class SetupPollCommand implements ICommandImpl {
 
         String url = Objects.requireNonNull(event.getOption("url")).getAsString();
 
-        executor.submit(() -> {
+        pollSetupExecutor.execute(() -> {
+            Path tempDir = null;
             try {
+                tempDir = Files.createTempDirectory("poll-setup-");
+
                 Document doc = Jsoup.connect(url).get();
                 String castingCallTitle = doc.title();
                 log.info("Title from Casting Call Club: {}", castingCallTitle);
@@ -108,7 +112,7 @@ public class SetupPollCommand implements ICommandImpl {
                     String threadName = roleName + " Auditions";
                     Message startMessage = event.getChannel().sendMessage("Auditions for " + entry.getKey()).complete();
                     ThreadChannel threadChannelAction = startMessage.createThreadChannel(threadName).complete();
-                    sendAudioFiles(new ArrayList<>(entry.getValue()), threadChannelAction);
+                    sendAudioFiles(new ArrayList<>(entry.getValue()), threadChannelAction, tempDir);
                 }
 
                 event.getHook().editOriginal("Finished sending everything").queue();
@@ -121,6 +125,18 @@ public class SetupPollCommand implements ICommandImpl {
             } catch (Exception e) {
                 log.error("Unexpected error during poll setup", e);
                 event.getHook().editOriginal("An error occurred: " + e.getMessage()).queue();
+            } finally {
+                if (tempDir != null) {
+                    try {
+                        try (var stream = Files.walk(tempDir)) {
+                            stream.sorted(Comparator.reverseOrder()).forEach(p -> {
+                                try { Files.deleteIfExists(p); } catch (IOException ignored) {}
+                            });
+                        }
+                    } catch (IOException e) {
+                        log.warn("Failed to clean up temp directory: {}", tempDir, e);
+                    }
+                }
             }
         });
     }
@@ -224,7 +240,7 @@ public class SetupPollCommand implements ICommandImpl {
         return null;
     }
 
-    private void sendAudioFiles(ArrayList<JSONObject> auditions, MessageChannel channel) {
+    private void sendAudioFiles(ArrayList<JSONObject> auditions, MessageChannel channel, Path tempDir) {
         for (int j = 0; j < auditions.size(); j++) {
             JSONObject audition = auditions.get(j);
             String audioURL = audition.getString("audioUrl");
@@ -237,18 +253,18 @@ public class SetupPollCommand implements ICommandImpl {
 
             try {
                 URL website = new URL(audioURL);
+                File file = tempDir.resolve(audioFileName).toFile();
                 try (ReadableByteChannel rbc = Channels.newChannel(website.openStream());
-                     FileOutputStream fos = new FileOutputStream(audioFileName)) {
+                     FileOutputStream fos = new FileOutputStream(file)) {
                     fos.getChannel().transferFrom(rbc, 0, Long.MAX_VALUE);
                 }
-                File file = new File(audioFileName);
 
                 // Convert/compress via FFmpeg (no-op if already MP3 < 7MB, deletes original if conversion runs)
                 try {
                     file = audioConversionService.convertToMp3(file);
                 } catch (IOException e) {
                     log.warn("Audio conversion failed for {}, skipping: {}", safeUserName, e.getMessage());
-                    Files.deleteIfExists(new File(audioFileName).toPath());
+                    Files.deleteIfExists(file.toPath());
                     continue;
                 }
 

--- a/src/main/java/me/kmaxi/wynnvp/controller/discordcommands/SetupPollCommand.java
+++ b/src/main/java/me/kmaxi/wynnvp/controller/discordcommands/SetupPollCommand.java
@@ -86,73 +86,77 @@ public class SetupPollCommand implements ICommandImpl {
 
         String url = Objects.requireNonNull(event.getOption("url")).getAsString();
 
-        pollSetupExecutor.execute(() -> {
-            Path tempDir = null;
-            try {
-                try {
-                    FileAttribute<Set<PosixFilePermission>> ownerOnly =
-                            PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("rwx------"));
-                    tempDir = Files.createTempDirectory("poll-setup-", ownerOnly);
-                } catch (UnsupportedOperationException e) {
-                    // Non-POSIX filesystem (e.g. Windows) — restrict permissions explicitly
-                    tempDir = Files.createTempDirectory("poll-setup-");
-                    File dir = tempDir.toFile();
-                    dir.setReadable(true, true);
-                    dir.setWritable(true, true);
-                    dir.setExecutable(true, true);
-                }
+        pollSetupExecutor.execute(() -> setupPollFromUrl(event, url));
+    }
 
-                Document doc = Jsoup.connect(url).get();
-                String castingCallTitle = doc.title();
-                log.info("Title from Casting Call Club: {}", castingCallTitle);
+    private void setupPollFromUrl(SlashCommandInteractionEvent event, String url) {
+        Path tempDir = null;
+        try {
+            tempDir = createSecureTempDirectory();
 
-                String projectId = getProjectId(doc);
-                log.info("Found project ID: {}", projectId);
+            Document doc = Jsoup.connect(url).get();
+            log.info("Title from Casting Call Club: {}", doc.title());
 
-                ArrayList<JSONObject> allSubmissions = getAllSubmissions(projectId);
-                log.info("Total submissions fetched: {}", allSubmissions.size());
+            String projectId = getProjectId(doc);
+            log.info("Found project ID: {}", projectId);
 
-                event.getChannel().sendMessage("Auditions for " + url).queue();
+            ArrayList<JSONObject> allSubmissions = getAllSubmissions(projectId);
+            log.info("Total submissions fetched: {}", allSubmissions.size());
 
-                // Group by role name
-                Map<String, List<JSONObject>> byRole = new LinkedHashMap<>();
-                for (JSONObject sub : allSubmissions) {
-                    String roleName = sub.getString("roleName").trim();
-                    byRole.computeIfAbsent(roleName, k -> new ArrayList<>()).add(sub);
-                }
+            event.getChannel().sendMessage("Auditions for " + url).queue();
 
-                for (Map.Entry<String, List<JSONObject>> entry : byRole.entrySet()) {
-                    String roleName = entry.getKey().replaceAll("[ ,.-]", "_");
-                    String threadName = roleName + " Auditions";
-                    Message startMessage = event.getChannel().sendMessage("Auditions for " + entry.getKey()).complete();
-                    ThreadChannel threadChannelAction = startMessage.createThreadChannel(threadName).complete();
-                    sendAudioFiles(new ArrayList<>(entry.getValue()), threadChannelAction, tempDir);
-                }
-
-                event.getHook().editOriginal("Finished sending everything").queue();
-
-            } catch (CccAuthException e) {
-                event.getHook().editOriginal("CCC authentication failed — your token is invalid or expired. Please update it in the bot configuration.").queue();
-            } catch (IOException e) {
-                log.error("Error while trying to connect to the URL: {}", url, e);
-                event.getHook().editOriginal("Failed to connect to the URL: " + e.getMessage()).queue();
-            } catch (Exception e) {
-                log.error("Unexpected error during poll setup", e);
-                event.getHook().editOriginal("An error occurred: " + e.getMessage()).queue();
-            } finally {
-                if (tempDir != null) {
-                    try {
-                        try (var stream = Files.walk(tempDir)) {
-                            stream.sorted(Comparator.reverseOrder()).forEach(p -> {
-                                try { Files.deleteIfExists(p); } catch (IOException ignored) {}
-                            });
-                        }
-                    } catch (IOException e) {
-                        log.warn("Failed to clean up temp directory: {}", tempDir, e);
-                    }
-                }
+            Map<String, List<JSONObject>> byRole = new LinkedHashMap<>();
+            for (JSONObject sub : allSubmissions) {
+                byRole.computeIfAbsent(sub.getString("roleName").trim(), k -> new ArrayList<>()).add(sub);
             }
-        });
+
+            for (Map.Entry<String, List<JSONObject>> entry : byRole.entrySet()) {
+                String roleName = entry.getKey().replaceAll("[ ,.-]", "_");
+                Message startMessage = event.getChannel().sendMessage("Auditions for " + entry.getKey()).complete();
+                ThreadChannel threadChannel = startMessage.createThreadChannel(roleName + " Auditions").complete();
+                sendAudioFiles(new ArrayList<>(entry.getValue()), threadChannel, tempDir);
+            }
+
+            event.getHook().editOriginal("Finished sending everything").queue();
+
+        } catch (CccAuthException e) {
+            event.getHook().editOriginal("CCC authentication failed — your token is invalid or expired. Please update it in the bot configuration.").queue();
+        } catch (IOException e) {
+            log.error("Error while trying to connect to the URL: {}", url, e);
+            event.getHook().editOriginal("Failed to connect to the URL: " + e.getMessage()).queue();
+        } catch (Exception e) {
+            log.error("Unexpected error during poll setup", e);
+            event.getHook().editOriginal("An error occurred: " + e.getMessage()).queue();
+        } finally {
+            cleanupTempDir(tempDir);
+        }
+    }
+
+    private Path createSecureTempDirectory() throws IOException {
+        try {
+            FileAttribute<Set<PosixFilePermission>> ownerOnly =
+                    PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("rwx------"));
+            return Files.createTempDirectory("poll-setup-", ownerOnly);
+        } catch (UnsupportedOperationException e) {
+            // Non-POSIX filesystem (e.g. Windows) — restrict permissions explicitly
+            Path tempDir = Files.createTempDirectory("poll-setup-");
+            File dir = tempDir.toFile();
+            if (!dir.setReadable(true, true) || !dir.setWritable(true, true) || !dir.setExecutable(true, true)) {
+                throw new IOException("Failed to restrict permissions on temp directory: " + tempDir);
+            }
+            return tempDir;
+        }
+    }
+
+    private void cleanupTempDir(Path tempDir) {
+        if (tempDir == null) return;
+        try (var stream = Files.walk(tempDir)) {
+            stream.sorted(Comparator.reverseOrder()).forEach(p -> {
+                try { Files.deleteIfExists(p); } catch (IOException ignored) { /* best-effort deletion */ }
+            });
+        } catch (IOException e) {
+            log.warn("Failed to clean up temp directory: {}", tempDir, e);
+        }
     }
 
     private String getProjectId(Document doc) {

--- a/src/main/java/me/kmaxi/wynnvp/controller/discordcommands/SetupPollCommand.java
+++ b/src/main/java/me/kmaxi/wynnvp/controller/discordcommands/SetupPollCommand.java
@@ -33,6 +33,9 @@ import java.nio.channels.Channels;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.attribute.FileAttribute;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
 import java.util.*;
 import java.util.concurrent.Executor;
 
@@ -86,7 +89,14 @@ public class SetupPollCommand implements ICommandImpl {
         pollSetupExecutor.execute(() -> {
             Path tempDir = null;
             try {
-                tempDir = Files.createTempDirectory("poll-setup-");
+                try {
+                    FileAttribute<Set<PosixFilePermission>> ownerOnly =
+                            PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("rwx------"));
+                    tempDir = Files.createTempDirectory("poll-setup-", ownerOnly);
+                } catch (UnsupportedOperationException e) {
+                    // Non-POSIX filesystem (e.g. Windows) — default temp dir permissions apply
+                    tempDir = Files.createTempDirectory("poll-setup-");
+                }
 
                 Document doc = Jsoup.connect(url).get();
                 String castingCallTitle = doc.title();


### PR DESCRIPTION
JDA's slash command events are dispatched on inWS-ReadThread. When processing large quests with hundreds of submissions, downloading and converting audio files can take several minutes, blocking this thread the entire time. JDA's heartbeat mechanism runs concurrently. After missing 2 heartbeats it reconnects by interrupting inWS-ReadThread. This interrupt propagates as ClosedByInterruptException on any active FileChannel I/O, causing all remaining audio downloads to fail.

Fix by submitting the heavy work to a cached ExecutorService immediately after deferring the slash command reply. The JDA thread returns right away and can send heartbeats normally, while the background thread handles all fetching, FFmpeg conversion, and Discord uploads without risk of interruption.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Optimized the poll setup process with enhanced background execution for improved responsiveness and reliability during submission handling and message creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->